### PR TITLE
Fixed the name of school

### DIFF
--- a/resume.tex
+++ b/resume.tex
@@ -19,7 +19,7 @@
 }
 
 \section{\faGraduationCap\ Education}
-\datedsubsection{\textbf{ChengDu Foreign Languages School (CDFLS)}, Chengdu, China}{2015.9 -- Present}
+\datedsubsection{\textbf{Chengdu Foreign Languages School (CFLS)}, Chengdu, China}{2015.9 -- Present}
 
 \section{\faUsers\ Experience}
 \datedsubsection{\textbf{FriceEngine}}{\url{https://icela.github.io/}}


### PR DESCRIPTION
Changed 'ChengDu' to 'Chengdu', as well as the abbreviation into canonical form.

Reference: https://en.wikipedia.org/wiki/Chengdu_Foreign_Languages_School

Feel free to correct the Wikipedia page and the domain name in "http://www.cfls.net.cn" if I am wrong :)