### PR TITLE
Fixing misuse of "mostly"

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,5 +24,5 @@ $ make en
 
 # Fun fact
 
-Possibly this is the mostly forked **personal** resume repository:<br/>
+Possibly this is the most forked **personal** resume repository:<br/>
 ![](./art/forks.png)


### PR DESCRIPTION
`mostly` 表示大部分，几乎全部。
此处用 `most` 更准确。