### PR TITLE
fix: comma style

### DIFF
--- a/Resume.hs
+++ b/Resume.hs
@@ -25,7 +25,7 @@ plct = paragraph
 singularityData :: Resume
 singularityData = paragraph
   [ datedSection2 (date "2022" "7" ~~ present) $ paragraph
-    [ cn "\\textbf{北京奇点无限数据科技有限公司}，远程"
+    [ cn "\\textbf{北京奇点无限数据科技有限公司}, 远程"
     , en "\\textbf{RisingWave Labs}, Remote"
     ]
   , paragraph


### PR DESCRIPTION
PR without actually building the PDF artifacts, because of missing font:

```plaintext
! Package fontspec Error: The font "TeX Gyre Pagella" cannot be found.

For immediate help type H <return>.
 ...

l.19 \urlstyle
              {same}
? ^C^C^D
! Emergency stop.
```

Anyway, it's trivial.